### PR TITLE
fix: Add file extension for macOS test runner

### DIFF
--- a/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs
+++ b/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 
 using RuntimeUnitTestToolkit;
 using RuntimeUnitTestToolkit.Editor;
@@ -118,7 +118,7 @@ public static partial class UnitTestBuilder
 
         if (buildPath == null)
         {
-            buildPath = $"bin/UnitTest/{settings.BuildTarget}_{settings.ScriptBackend}/test" + (IsWindows(settings.BuildTarget) ? ".exe" : "");
+            buildPath = $"bin/UnitTest/{settings.BuildTarget}_{settings.ScriptBackend}/test" + GetExtensionForBuildTarget(settings.BuildTarget);
         }
 
         var originalScene = SceneManager.GetActiveScene().path;
@@ -457,20 +457,42 @@ public static partial class UnitTestBuilder
         }
     }
 
+    static string GetExtensionForBuildTarget(BuildTarget buildTarget)
+    {
+        switch (buildTarget)
+        {
+            case BuildTarget.StandaloneWindows:
+            case BuildTarget.StandaloneWindows64:
+            case BuildTarget.WSAPlayer:
+                return ".exe";
+            case BuildTarget.StandaloneOSX:                
+                return ".app";
+            case BuildTarget.Android:
+                return ".apk";
+            default:
+                return "";
+        }
+    }
+
     static BuildTargetGroup ToBuildTargetGroup(BuildTarget buildTarget)
     {
 #pragma warning disable CS0618
         switch (buildTarget)
         {
+#if UNITY_2017_3_OR_NEWER
             case BuildTarget.StandaloneOSX:
-            case (BuildTarget)3:
+#else
             case BuildTarget.StandaloneOSXIntel:
             case BuildTarget.StandaloneOSXIntel64:
+            case BuildTarget.StandaloneOSXUniversal:
+#endif // UNITY_2017_3_OR_NEWER
             case BuildTarget.StandaloneWindows:
             case BuildTarget.StandaloneWindows64:
-            case BuildTarget.StandaloneLinux:
             case BuildTarget.StandaloneLinux64:
+#if !UNITY_2019_2_OR_NEWER
+            case BuildTarget.StandaloneLinux:
             case BuildTarget.StandaloneLinuxUniversal:
+#endif // !UNITY_2019_2_OR_NEWER
                 return BuildTargetGroup.Standalone;
             case (BuildTarget)6:
             case (BuildTarget)7:


### PR DESCRIPTION
modified UnitTestBuilder.BuildUnitTest() to add file extension for macOS
modified UnitTestBuilder.ToBuildTargetGroup() to remove the deprecated warnings