### PR TITLE
chore: replace set-env to ENV FILE $GITHUB_ENV

### DIFF
--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -3,7 +3,7 @@ name: Unity-Build
 on:
   push:
     branches:
-      - "**"
+      - "master"
     tags:
       - "!*" # not a tag push
   pull_request:

--- a/.github/workflows/unity-release.yml
+++ b/.github/workflows/unity-release.yml
@@ -9,7 +9,7 @@ jobs:
   build-unity:
     strategy:
       matrix:
-        unity: ['2019.3.9f1']
+        unity: ["2019.3.9f1"]
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
@@ -26,7 +26,7 @@ jobs:
       - run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
 
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # Execute scripts: Export Package
       - name: Export unitypackage
@@ -40,7 +40,7 @@ jobs:
         with:
           name: RuntimeUnitTestToolkit.${{ env.GIT_TAG }}.unitypackage
           path: ./RuntimeUnitTestToolkit/RuntimeUnitTestToolkit.${{ env.GIT_TAG }}.unitypackage
-          
+
       # Create Releases
       - uses: actions/create-release@v1
         id: create_release


### PR DESCRIPTION
* fix https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* push build on master