### PR TITLE
fix: Editor Menu not show when install with UPM.

### DIFF
--- a/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/package.json
+++ b/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/package.json
@@ -6,6 +6,6 @@
     "description": "CLI/GUI Frontend of Unity Test Runner to test on any platform.",
     "keywords": ["test"],
     "category": "Tests",
-    "dependencies": {
-    }
+    "dependencies": {},
+    "type": "tests"
 }


### PR DESCRIPTION
closed https://github.com/Cysharp/RuntimeUnitTestToolkit/issues/13

This is due to lack of entry `"type": "tests"` for package.json.

reproduce issue and confirmed fix on...

* [x] Unity 2020.1.1f1
* [x] Unity 2021.2.7f1

![image](https://user-images.githubusercontent.com/3856350/117704992-75c00b00-b206-11eb-8cec-9eedcdc72bcc.png)

![image](https://user-images.githubusercontent.com/3856350/117704963-6d67d000-b206-11eb-83aa-44098de25937.png)


## NOTE

It's undocumented.

> type:| A constant that provides additional information to the Package Manager.Reserved for internal use.
> https://docs.unity3d.com/2021.2/Documentation/Manual/upm-manifestPkg.html

![image](https://user-images.githubusercontent.com/3856350/117705372-ed8e3580-b206-11eb-829d-1ae7a8a13d3c.png)
