### PR TITLE
fixed headless mode not working in unity 2021.2

### DIFF
--- a/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs
+++ b/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/Editor/UnitTestBuilder.cs
@@ -395,10 +395,12 @@ public static partial class UnitTestBuilder
         {
             options |= BuildOptions.AutoRunPlayer;
         }
+#if !UNITY_2021_2_OR_NEWER
         if (settings.Headless)
         {
             options |= BuildOptions.EnableHeadlessMode;
         }
+#endif
 
         var targetGroup = ToBuildTargetGroup(settings.BuildTarget);
         var currentBackend = PlayerSettings.GetScriptingBackend(targetGroup);
@@ -416,6 +418,13 @@ public static partial class UnitTestBuilder
             scenes = new[] { sceneName },
             locationPathName = buildPath
         };
+
+#if UNITY_2021_2_OR_NEWER
+        if (settings.Headless)
+        {
+            buildOptions.subtarget = (int)StandaloneBuildSubtarget.Server;
+        }
+#endif
 
         UnityEngine.Debug.Log("UnitTest Build Start, " + settings.ToString());
 

--- a/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/package.json
+++ b/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/package.json
@@ -2,7 +2,7 @@
     "name": "com.cysharp.runtimeunittesttoolkit",
     "displayName": "RuntimeUnitTestToolkit",
     "author": { "name": "Cysharp, Inc.", "url": "https://cysharp.co.jp/en/" },
-    "version": "2.5.2",
+    "version": "2.5.3",
     "unity": "2018.3",
     "description": "CLI/GUI Frontend of Unity Test Runner to test on any platform.",
     "keywords": ["test"],


### PR DESCRIPTION
Using this toolkit in my project using _unity 2021.2_ I've noticed that enabling headless mode from the menu wasn't doing anything.
Since I really wanted to use this feature I did some troubleshooting and it turns out it was working correctly up until _unity 2021.1_.
However as of _unity 2021.2_ they made [BuildOptions.EnableHeadlessMode obsolete](https://docs.unity3d.com/2021.2/Documentation/ScriptReference/BuildOptions.EnableHeadlessMode.html) and it seams like they are already ignoring it entirely too.

Luckily you can still get the same behaviour by setting
```cs
BuildPlayerOptions.subtarget = (int)StandaloneBuildSubtarget.Server;
```
It's kinda wired they made that property an _int_ but it works perfectly.
I also bumped the minor version on the package.json for upm.