### PR TITLE
Exclude abstract test classes

### DIFF
--- a/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/UnitTestData.cs
+++ b/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/UnitTestData.cs
@@ -34,6 +34,11 @@ namespace RuntimeUnitTestToolkit
 
                 foreach (var item in assembly.GetTypes())
                 {
+                    if (item.IsAbstract)
+                    {
+                        continue;
+                    }
+
                     SetUpFixtureAttribute setupFixture;
                     try
                     {


### PR DESCRIPTION
# Changes
- Exclude abstract test classes
  - If some abstract test classes exist, `MissingMethodException` will be thrown from [Activator.CreateInstance](https://github.com/Cysharp/RuntimeUnitTestToolkit/blob/f7d60f1c7efbbb30d9916dfd65b5b46cc6f1991f/RuntimeUnitTestToolkit/Assets/RuntimeUnitTestToolkit/UnitTestData.cs#L207) and tests won't loaded

![image](https://user-images.githubusercontent.com/19503967/156608713-874cf2ba-0339-40c3-8767-db9aa2a41840.png)
