### PR TITLE
ci: speed up and stabilize

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -53,7 +53,7 @@ jobs:
 
       # Execute Unittest Mono2x (4m 30s)
       # # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend Mono2x /BuildTarget StandaloneLinux64
-    #   - name: Build UnitTest
+    #   - name: Build UnitTest (Mono2x)
     #     uses: Cysharp/Actions/.github/actions/unity-builder@main
     #     env:
     #       UNITY_EMAIL: ${{ steps.op-load-secret.outputs.UNITY_EMAIL }}
@@ -75,7 +75,7 @@ jobs:
 
       # Execute Unittest IL2CPP (4m 30s)
       # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend IL2CPP /BuildTarget StandaloneLinux64
-      - name: Build UnitTest
+      - name: Build UnitTest (IL2CPP)
         uses: Cysharp/Actions/.github/actions/unity-builder@main
         env:
           UNITY_EMAIL: ${{ steps.op-load-secret.outputs.UNITY_EMAIL }}

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -13,6 +13,7 @@ jobs:
     if: ${{ ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:')) && github.triggering_actor != 'dependabot[bot]' }}
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         unity: ["2021.3.41f1", "2022.3.39f1", "6000.0.12f1"] # Test with LTS
     runs-on: ubuntu-latest

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -51,28 +51,29 @@ jobs:
         with:
           directory: RuntimeUnitTestToolkit
 
-      # Execute Unittest
-      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend Mono2x /BuildTarget StandaloneLinux64
-      - name: Build UnitTest
-        uses: Cysharp/Actions/.github/actions/unity-builder@main
-        env:
-          UNITY_EMAIL: ${{ steps.op-load-secret.outputs.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ steps.op-load-secret.outputs.UNITY_PASSWORD }}
-          UNITY_SERIAL: ${{ steps.op-load-secret.outputs.UNITY_SERIAL }}
-        with:
-          projectPath: RuntimeUnitTestToolkit
-          unityVersion: ${{ matrix.unity }}
-          targetPlatform: StandaloneLinux64
-          buildMethod: UnitTestBuilder.BuildUnitTest
-          customParameters: "/headless /ScriptBackend Mono2x"
-      - name: Check UnitTest file is generated
-        run: ls -lR ./RuntimeUnitTestToolkit/bin/UnitTest
-      - name: Execute UnitTest
-        run: ./RuntimeUnitTestToolkit/bin/UnitTest/StandaloneLinux64_Mono2x/test
+      # Execute Unittest Mono2x (4m 30s)
+      # # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend Mono2x /BuildTarget StandaloneLinux64
+    #   - name: Build UnitTest
+    #     uses: Cysharp/Actions/.github/actions/unity-builder@main
+    #     env:
+    #       UNITY_EMAIL: ${{ steps.op-load-secret.outputs.UNITY_EMAIL }}
+    #       UNITY_PASSWORD: ${{ steps.op-load-secret.outputs.UNITY_PASSWORD }}
+    #       UNITY_SERIAL: ${{ steps.op-load-secret.outputs.UNITY_SERIAL }}
+    #     with:
+    #       projectPath: RuntimeUnitTestToolkit
+    #       unityVersion: ${{ matrix.unity }}
+    #       targetPlatform: StandaloneLinux64
+    #       buildMethod: UnitTestBuilder.BuildUnitTest
+    #       customParameters: "/headless /ScriptBackend Mono2x"
+    #   - name: Check UnitTest file is generated
+    #     run: ls -lR ./RuntimeUnitTestToolkit/bin/UnitTest
+    #   - name: Execute UnitTest
+    #     run: ./RuntimeUnitTestToolkit/bin/UnitTest/StandaloneLinux64_Mono2x/test
 
-      - name: Remove Library
-        run: sudo rm -rf ./RuntimeUnitTestToolkit/Library
+    #   - name: Remove Library
+    #     run: sudo rm -rf ./RuntimeUnitTestToolkit/Library
 
+      # Execute Unittest IL2CPP (4m 30s)
       # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend IL2CPP /BuildTarget StandaloneLinux64
       - name: Build UnitTest
         uses: Cysharp/Actions/.github/actions/unity-builder@main

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -35,6 +35,7 @@ jobs:
       # Execute scripts: Export Package
       # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
       - name: Build Unity (.unitypacakge)
+        if: ${{ startsWith(matrix.unity, '2021') }} # only execute once
         uses: Cysharp/Actions/.github/actions/unity-builder@main
         env:
           UNITY_EMAIL: ${{ steps.op-load-secret.outputs.UNITY_EMAIL }}
@@ -92,6 +93,7 @@ jobs:
 
       # Store artifacts.
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
+        if: ${{ startsWith(matrix.unity, '2021') }} # only execute once
         with:
           name: RuntimeUnitTestToolkit.${{ matrix.unity }}.unitypackage.zip
           path: ./RuntimeUnitTestToolkit/*.unitypackage


### PR DESCRIPTION
## tl;dr;

Change CI workflow to stabilize and speed up.

**Stabilize**

* max-parallel: 2 to admit Unity License Concurrent limit.

**Speed up**

* run package build once.
* skip Mono UnitTest.

## before

Each version takes 11m

* Build Unity (.unitypackage): 2m 22s
* Build Unity Test (Mono2x): 4m 35s
* Build Unity Test (IL2CPP): 4m 9s

![image](https://github.com/user-attachments/assets/e1fad1d0-4199-406f-806d-8546cf6c92ec)

![image](https://github.com/user-attachments/assets/a8896d91-9b63-4762-97dc-bc37d92d9dcd)

## after

Each version takes about 6m

* Build Unity (.unitypackage): 2m 22s (Unity 2021 only)
* Build Unity Test (Mono2x): skip
* Build Unity Test (IL2CPP): 4m 9s (All version)


![image](https://github.com/user-attachments/assets/7fc8f219-5c24-4dda-b8e4-0f682d5b5645)

![image](https://github.com/user-attachments/assets/ecdecff8-78ad-4a1a-a384-9e2e98042596)
